### PR TITLE
Changed compositing operation to show icons

### DIFF
--- a/AMPrefs/AMPrefPaneIconView.m
+++ b/AMPrefs/AMPrefPaneIconView.m
@@ -407,8 +407,8 @@ NSInteger _am_compareByCategory(id array1, id array2, void *prefsController)
 {
 	NSRect frame = [self frameForCategoryWithIndex:index];
 	if ((index % 2) == 1) {
-		[[NSColor colorWithCalibratedWhite:0.97 alpha:0.99] set];
-		NSRectFillUsingOperation(frame, NSCompositePlusDarker);
+		[[NSColor colorWithCalibratedWhite:0.97 alpha:1] set];
+		NSRectFill(frame);
 	}
 	if (sortByCategory) {
 		NSPoint captionOffset = NSMakePoint(AMPrefPaneIconViewHorizontalPadding, frame.origin.y +AMPrefPaneIconViewTopGroupPadding);
@@ -438,8 +438,8 @@ NSInteger _am_compareByCategory(id array1, id array2, void *prefsController)
 	} else {
 		theImage = [icon image];
 	}
-	[theImage setFlipped:NO];
-	[theImage drawInRect:iconRect fromRect:sourceRect operation:NSCompositeSourceAtop fraction:1.0];
+	[theImage setFlipped:YES];
+	[theImage drawInRect:iconRect fromRect:sourceRect operation:NSCompositingOperationSourceOver fraction:1.0];
 	NSRect labelRect = NSZeroRect;
 	labelRect.size = [[icon title] sizeWithAttributes:_am_iconLabelAttributes];
 	labelRect.origin.x = pos.x-labelRect.size.width/2.0;


### PR DESCRIPTION
Hi!

This is my proposition to fix non showing icons in Preferences->Show All view.

Generally this is a problem of composition, I solved it this way, I guess it may be solved differently.

I think there are many other things that need change in Preferences like:

- Look for some modern icons to represent panes
- Dark/Light/Auto mode and unified colors
- Preferences should not be customizable - let's make them simpler.
- Toolbar under window name - like Safari and other modern apps.
- I thought about creating nib for Preferences Pane

But probably this is a topic for a new issue or PR?